### PR TITLE
Fix: resolve Zizmor template and env findings

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -57,14 +57,20 @@ runs:
     - name: "Check Python package index"
       id: check
       shell: bash
+      env:
+        INPUT_INDEX_URL: "${{ inputs.INDEX_URL }}"
+        INPUT_PACKAGE_NAME: "${{ inputs.PACKAGE_NAME }}"
+        INPUT_PACKAGE_VERSION: "${{ inputs.PACKAGE_VERSION }}"
+        INPUT_PRE_RELEASE: "${{ inputs.PRE_RELEASE }}"
+        INPUT_EXIT_ON_FAIL: "${{ inputs.EXIT_ON_FAIL }}"
       run: |
         # Check Python package index
-        INDEX_URL="${{ inputs.INDEX_URL }}"
-        PACKAGE_NAME="${{ inputs.PACKAGE_NAME }}"
-        PACKAGE_VERSION="${{ inputs.PACKAGE_VERSION }}"
-        PRE_RELEASE=$(echo ${{ inputs.PRE_RELEASE }} |\
+        INDEX_URL="$INPUT_INDEX_URL"
+        PACKAGE_NAME="$INPUT_PACKAGE_NAME"
+        PACKAGE_VERSION="$INPUT_PACKAGE_VERSION"
+        PRE_RELEASE=$(printf '%s' "$INPUT_PRE_RELEASE" |\
         tr '[:upper:]' '[:lower:]')
-        EXIT_ON_FAIL=$(echo ${{ inputs.EXIT_ON_FAIL }} |\
+        EXIT_ON_FAIL=$(printf '%s' "$INPUT_EXIT_ON_FAIL" |\
           tr '[:upper:]' '[:lower:]')
 
         if [[ "$PACKAGE_VERSION" == v* ]]; then
@@ -129,7 +135,5 @@ runs:
           echo "Error: a query failed to return results ❌"
           exit 1
         fi
-        echo "package_match=$PACKAGE_MATCH" >> "$GITHUB_ENV"
         echo "package_match=$PACKAGE_MATCH" >> "$GITHUB_OUTPUT"
-        echo "version_match=$VERSION_MATCH" >> "$GITHUB_ENV"
         echo "version_match=$VERSION_MATCH" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Resolves all medium+ findings reported by the org-wide Zizmor audit for
this repository (5 `template-injection`, 2 `github-env`).

## Changes

- Route the five inputs consumed by the `Check Python package index`
  step (`INDEX_URL`, `PACKAGE_NAME`, `PACKAGE_VERSION`, `PRE_RELEASE`,
  `EXIT_ON_FAIL`) through the step `env:` block as `INPUT_*` variables,
  referenced as quoted shell variables, so nothing is interpolated
  directly into the `run:` body.
- Drop the redundant `package_match` / `version_match` writes to
  `$GITHUB_ENV`. Both values are already exposed through the action's
  declared step outputs `PACKAGE_MATCH` / `VERSION_MATCH` (the
  documented contract, sourced from `$GITHUB_OUTPUT`); the `$GITHUB_ENV`
  exports were undocumented duplicates and the sole cause of the
  `github-env` findings.

Behaviour is preserved. Verified with `zizmor --persona regular
--min-severity medium` reporting 0 findings.